### PR TITLE
fix: return null when there is no last task attempt

### DIFF
--- a/pages/api/tasks/module/[...id].ts
+++ b/pages/api/tasks/module/[...id].ts
@@ -51,7 +51,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     return {
       task_data: task,
-      last_attempt: Object.keys(result).length === 0 ? null : result,
+      last_attempt: result.attempt_id ? result : null,
     };
   });
 


### PR DESCRIPTION
Updated `/api/tasks/module/[id]` endpoint to return null when user has no last attempt.